### PR TITLE
Added tests and changed imports plus reverted one change

### DIFF
--- a/.github/workflows/zig-release.yaml
+++ b/.github/workflows/zig-release.yaml
@@ -25,8 +25,8 @@ jobs:
         run: zig build -Dtarget=aarch64-macos
       - name: MacOS 
         run: zig build -Dtarget=x86_64-linux
-      - name: Linux
+      - name: Linux-aarch64
         run: zig build -Dtarget=aarch64-linux
+      - name: Linux
         run: zig build -Dtarget=x86_64-linux
-        run: zig build -Dtarget=
 

--- a/build.zig
+++ b/build.zig
@@ -4,19 +4,53 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const ansi_module = b.addModule("ansi", .{
+        .root_source_file = .{ .cwd_relative = "src/libs/ansi_codes.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const search_module = b.addModule("search", .{
+        .root_source_file = .{ .cwd_relative = "src/packages/search.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    search_module.addImport("ansi", ansi_module);
+
+    const main_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    main_module.addImport("search", search_module);
+    main_module.addImport("ansi", ansi_module);
+
     const exe = b.addExecutable(.{
         .name = "zigp",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/main.zig"),
-
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = main_module,
     });
 
     exe.linkLibC();
 
     b.installArtifact(exe);
+
+    const search_test_module = b.addModule("search-tests", .{ .root_source_file = .{ .cwd_relative = "tests/search_test.zig" }, .target = target, .optimize = optimize });
+    search_test_module.addImport("search", search_module);
+
+    const search_tests = b.addTest(.{
+        .root_module = search_test_module,
+    });
+
+    const run_search_tests = b.addRunArtifact(search_tests);
+
+    // Test steps
+    const test_step = b.step("test", "Run all tests");
+    test_step.dependOn(&run_search_tests.step);
+
+    const search_test_step = b.step("test-search", "Run search tests only");
+    search_test_step.dependOn(&run_search_tests.step);
 
     const run_step = b.step("run", "Run the app");
 

--- a/modules.zig
+++ b/modules.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub fn buildModules(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) struct {
+    ansi: *std.Build.Module,
+    search: *std.Build.Module,
+    main: *std.Build.Module,
+} {
+    const ansi_module = b.addModule("ansi", .{
+        .root_source_file = .{ .cwd_relative = "src/libs/ansi_codes.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const search_module = b.addModule("search", .{
+        .root_source_file = .{ .cwd_relative = "src/packages/search.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    search_module.addImport("ansi", ansi_module);
+
+    const main_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    main_module.addImport("search", search_module);
+    main_module.addImport("ansi", ansi_module);
+
+    return .{
+        .ansi = ansi_module,
+        .search = search_module,
+        .main = main_module,
+    };
+}

--- a/src/libs/display.zig
+++ b/src/libs/display.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("./ansi_codes.zig");
+const ansi = @import("ansi");
 
 pub const help = struct {
     pub fn remove_info() void {

--- a/src/libs/helper_functions.zig
+++ b/src/libs/helper_functions.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("./ansi_codes.zig");
+const ansi = @import("ansi");
 const types = @import("../types.zig");
 const display = @import("display.zig");
 const builtin = @import("builtin");
@@ -205,8 +205,8 @@ pub fn read_integer() !usize {
     // Windows terminal compatibility issues
     // Trim the carriage return
     const delimiters = switch (builtin.target.os.tag) {
-        .windows => " \n\t",
-        else => " \r\n\t",
+        .windows => " \r\n\t",
+        else => " \n\t",
     };
     const num_str = std.mem.trim(u8, num_str_cr, delimiters);
 

--- a/src/libs/init.zig
+++ b/src/libs/init.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("./ansi_codes.zig");
+const ansi = @import("ansi");
 const hfs = @import("./helper_functions.zig");
 
 const content =

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const program_manager = @import("./programs/install.zig");
 const types = @import("types.zig");
 const hfs = @import("./libs/helper_functions.zig");
 const init = @import("./libs/init.zig");
-const package_search = @import("./packages/search.zig");
+const search = @import("search");
 
 inline fn eql(x: []const u8, y: []const u8) bool {
     return std.mem.eql(u8, x, y);
@@ -96,7 +96,7 @@ pub fn main() !void {
         } else if (eql(args[1], "search")) {
             const query = if (args.len > 2) args[2] else null;
             const filter = if (args.len > 3) args[3] else null;
-            try package_search.search_packages(allocator, query, filter);
+            try search.search_packages(allocator, query, filter);
         } else if (eql(args[1], "remove")) {
             try remove_package.remove_dependency(allocator, args[2]);
         } else if (eql(args[1], "update")) {
@@ -151,7 +151,7 @@ pub fn main() !void {
         } else if (eql(args[1], "search")) {
             const query = if (args.len > 2) args[2] else null;
             const filter = if (args.len > 3) args[3] else null;
-            try package_search.search_packages(allocator, query, filter);
+            try search.search_packages(allocator, query, filter);
         } else display.err.unknown_argument(args[2]),
         // args[0]  args[1]     args[2]         args[3]
         // zigp     something   something_else  yet_something

--- a/src/packages/add.zig
+++ b/src/packages/add.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("../libs/ansi_codes.zig");
+const ansi = @import("ansi");
 const hfs = @import("../libs/helper_functions.zig");
 const types = @import("../types.zig");
 

--- a/src/packages/info.zig
+++ b/src/packages/info.zig
@@ -1,7 +1,7 @@
 const types = @import("../types.zig");
 const std = @import("std");
 const hfs = @import("../libs/helper_functions.zig");
-const ansi = @import("../libs/ansi_codes.zig");
+const ansi = @import("ansi");
 
 pub fn info(repo: types.repository, allocator: std.mem.Allocator) !void {
     const versions = try hfs.fetch_versions(repo, allocator);

--- a/src/packages/remove.zig
+++ b/src/packages/remove.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("../libs/ansi_codes.zig");
+const ansi = @import("ansi");
 const hfs = @import("../libs/helper_functions.zig");
 const types = @import("../types.zig");
 

--- a/src/packages/update.zig
+++ b/src/packages/update.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ansi = @import("../libs/ansi_codes.zig");
+const ansi = @import("ansi");
 const hfs = @import("../libs/helper_functions.zig");
 const types = @import("../types.zig");
 

--- a/src/programs/install.zig
+++ b/src/programs/install.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const display = @import("../libs/display.zig");
 const types = @import("../types.zig");
 const hfs = @import("../libs/helper_functions.zig");
-const ansi = @import("../libs/ansi_codes.zig");
+const ansi = @import("ansi");
 
 pub fn install_app(repo: types.repository, allocator: std.mem.Allocator) !void {
     std.debug.print("You are about to install a program, do you trust {s}https://github.com/{s}{s}? (Y/n): ", .{ ansi.BRIGHT_YELLOW ++ ansi.UNDERLINE, repo.full_name, ansi.RESET });

--- a/tests/http_mock.zig
+++ b/tests/http_mock.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const testing = std.testing;
+const http = std.http;
+
+// Mock HTTP Client
+pub const MockHttpClient = struct {
+    allocator: std.mem.Allocator,
+    expected_urls: std.ArrayList([]const u8),
+    responses: std.ArrayList(MockResponse),
+    requests_made: std.ArrayList(MockRequest),
+
+    const MockResponse = struct {
+        status: http.Status,
+        body: []const u8,
+    };
+
+    const MockRequest = struct {
+        url: []const u8,
+        method: ?http.Method,
+    };
+
+    pub fn init(allocator: std.mem.Allocator) MockHttpClient {
+        return .{
+            .allocator = allocator,
+            .expected_urls = std.ArrayList([]const u8){},
+            .responses = std.ArrayList(MockResponse){},
+            .requests_made = std.ArrayList(MockRequest){},
+        };
+    }
+
+    pub fn deinit(self: *MockHttpClient) void {
+        std.debug.print("Deinit called - freeing {} URLs, {} responses, {} requests\n", .{
+            self.expected_urls.items.len,
+            self.responses.items.len,
+            self.requests_made.items.len,
+        });
+
+        for (self.expected_urls.items) |url| {
+            std.debug.print("Freeing expected URL: {s}\n", .{url});
+            self.allocator.free(url);
+        }
+        self.expected_urls.deinit(self.allocator);
+
+        // Free any remaining response bodies
+        for (self.responses.items) |response| {
+            std.debug.print("Freeing remaining response body length: {}\n", .{response.body.len});
+            self.allocator.free(response.body);
+        }
+        self.responses.deinit(self.allocator);
+
+        for (self.requests_made.items) |req| {
+            std.debug.print("Freeing request URL: {s}\n", .{req.url});
+            self.allocator.free(req.url);
+        }
+        self.requests_made.deinit(self.allocator);
+    }
+
+    pub fn expectRequest(self: *MockHttpClient, url: []const u8, status: http.Status, response_body: []const u8) !void {
+        const url_copy = try self.allocator.dupe(u8, url);
+        const body_copy = try self.allocator.dupe(u8, response_body);
+
+        try self.expected_urls.append(self.allocator, url_copy);
+        try self.responses.append(self.allocator, .{
+            .status = status,
+            .body = body_copy,
+        });
+    }
+
+    pub fn fetch(self: *MockHttpClient, options: http.Client.FetchOptions) !http.Client.FetchResult {
+        // Store the request for verification
+        const url_copy = try self.allocator.dupe(u8, options.location.url);
+        try self.requests_made.append(self.allocator, .{
+            .url = url_copy,
+            .method = options.method,
+        });
+
+        // Check if we have a response for this request
+        if (self.responses.items.len == 0) {
+            return error.NoExpectedResponse;
+        }
+
+        const expected_response = self.responses.orderedRemove(0);
+
+        // Write response body to the provided writer
+        if (options.response_writer) |writer| {
+            try writer.writeAll(expected_response.body);
+        }
+
+        // FREE THE RESPONSE BODY AFTER USE!
+        self.allocator.free(expected_response.body);
+
+        return http.Client.FetchResult{
+            .status = expected_response.status,
+        };
+    }
+
+    pub fn getRequests(self: *const MockHttpClient) []const MockRequest {
+        return self.requests_made.items;
+    }
+
+    pub fn clearRequests(self: *MockHttpClient) void {
+        self.requests_made.clearRetainingCapacity();
+    }
+};

--- a/tests/search_test.zig
+++ b/tests/search_test.zig
@@ -1,0 +1,185 @@
+const std = @import("std");
+const testing = std.testing;
+const search = @import("search");
+const http_mock = @import("http_mock.zig");
+
+fn withCapturedOutput(
+    client: *http_mock.MockHttpClient,
+    comptime run: fn (*http_mock.MockHttpClient) anyerror!void,
+) !struct { stdout: []const u8, stderr: []const u8 } {
+    var out_buf: [8192]u8 = undefined;
+    var err_buf: [4096]u8 = undefined;
+
+    const out_fbs = std.io.fixedBufferStream(&out_buf);
+    const err_fbs = std.io.fixedBufferStream(&err_buf);
+
+    const stdout_file = std.fs.File.stdout();
+    const stderr_file = std.fs.File.stderr();
+
+    var stdout_writer_buf: [4096]u8 = undefined;
+    var stderr_writer_buf: [4096]u8 = undefined;
+
+    const old_stdout = stdout_file.writer(&stdout_writer_buf);
+    const old_stderr = stderr_file.writer(&stderr_writer_buf);
+
+    defer {
+        _ = old_stdout;
+        _ = old_stderr;
+    }
+
+    try run(client);
+
+    return .{
+        .stdout = out_fbs.getWritten(),
+        .stderr = err_fbs.getWritten(),
+    };
+}
+
+const TestContext = struct {
+    allocator: std.mem.Allocator,
+    mock_client: http_mock.MockHttpClient,
+
+    fn init(allocator: std.mem.Allocator) !TestContext {
+        return .{
+            .allocator = allocator,
+            .mock_client = http_mock.MockHttpClient.init(allocator),
+        };
+    }
+
+    fn deinit(self: *TestContext) void {
+        std.debug.print("Deinit called\n", .{});
+        self.mock_client.deinit();
+        std.debug.print("Deinit completed\n", .{});
+    }
+};
+
+test "search_packages: valid query and filter" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const mock_body_str =
+        \\ [{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"MLX.zig","full_name":"jaco-bro/MLX.zig","created_at":"2025-03-14T14:47:09Z","description":"MLX.zig: Phi-4, Llama 3.2, and Whisper in Zig","default_branch":"main","open_issues":2,"stargazers_count":28,"forks_count":4,"watchers_count":28,"tags_url":"https://api.github.com/repos/jaco-bro/MLX.zig/tags","license":"Apache-2.0","topics":["llama","llm","mlx","pcre2","regex","tiktoken","zig","zig-package"],"size":5431,"fork":false,"updated_at":"2025-10-02T01:55:39Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":[]},{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"tokenizer","full_name":"jaco-bro/tokenizer","created_at":"2025-04-19T04:26:17Z","description":"BPE tokenizer for LLMs in Pure Zig","default_branch":"main","open_issues":0,"stargazers_count":5,"forks_count":3,"watchers_count":5,"tags_url":"https://api.github.com/repos/jaco-bro/tokenizer/tags","license":"Apache-2.0","topics":["bpe-tokenizer","pcre2","regex","tokenizer","zig","zig-package"],"size":305,"fork":false,"updated_at":"2025-09-10T20:08:12Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":["https://github.com/allyourcodebase/boost-libraries-zig"]}]
+    ;
+
+    const mock_body = try testing.allocator.dupe(u8, mock_body_str);
+    defer testing.allocator.free(mock_body);
+
+    try ctx.mock_client.expectRequest(
+        "https://api.example.com/search?q=json&filter=http",
+        .ok,
+        mock_body,
+    );
+
+    _ = try withCapturedOutput(&ctx.mock_client, struct {
+        fn run(client: *http_mock.MockHttpClient) !void {
+            try search.search_packages_with_client(testing.allocator, client, "json", "http");
+        }
+    }.run);
+
+    try testing.expectEqual(@as(usize, 1), ctx.mock_client.getRequests().len);
+}
+
+test "search_packages: filter only" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const mock_body = try testing.allocator.dupe(u8,
+        \\ [{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"MLX.zig","full_name":"jaco-bro/MLX.zig","created_at":"2025-03-14T14:47:09Z","description":"MLX.zig: Phi-4, Llama 3.2, and Whisper in Zig","default_branch":"main","open_issues":2,"stargazers_count":28,"forks_count":4,"watchers_count":28,"tags_url":"https://api.github.com/repos/jaco-bro/MLX.zig/tags","license":"Apache-2.0","topics":["llama","llm","mlx","pcre2","regex","tiktoken","zig","zig-package"],"size":5431,"fork":false,"updated_at":"2025-10-02T01:55:39Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":[]},{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"tokenizer","full_name":"jaco-bro/tokenizer","created_at":"2025-04-19T04:26:17Z","description":"BPE tokenizer for LLMs in Pure Zig","default_branch":"main","open_issues":0,"stargazers_count":5,"forks_count":3,"watchers_count":5,"tags_url":"https://api.github.com/repos/jaco-bro/tokenizer/tags","license":"Apache-2.0","topics":["bpe-tokenizer","pcre2","regex","tokenizer","zig","zig-package"],"size":305,"fork":false,"updated_at":"2025-09-10T20:08:12Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":["https://github.com/allyourcodebase/boost-libraries-zig"]}]
+    );
+    defer testing.allocator.free(mock_body);
+
+    try ctx.mock_client.expectRequest("https://api.example.com/search?filter=http", .ok, mock_body);
+
+    _ = try withCapturedOutput(&ctx.mock_client, struct {
+        fn run(client: *http_mock.MockHttpClient) !void {
+            try search.search_packages_with_client(testing.allocator, client, null, "http");
+        }
+    }.run);
+
+    const requests = ctx.mock_client.getRequests();
+    try testing.expectEqual(@as(usize, 1), requests.len);
+    try testing.expect(!std.mem.containsAtLeast(u8, requests[0].url, 1, "q="));
+    try testing.expect(std.mem.containsAtLeast(u8, requests[0].url, 1, "filter=http"));
+}
+
+test "search_packages: empty query and filter returns error" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    _ = try withCapturedOutput(&ctx.mock_client, struct {
+        fn run(client: *http_mock.MockHttpClient) !void {
+            const result = search.search_packages_with_client(testing.allocator, client, null, null);
+            try testing.expectError(error.InvalidSearchParameters, result);
+        }
+    }.run);
+
+    try testing.expectEqual(@as(usize, 0), ctx.mock_client.getRequests().len);
+}
+
+test "search_packages: wildcard query treated as empty" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const mock_body = try testing.allocator.dupe(u8,
+        \\ [{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"MLX.zig","full_name":"jaco-bro/MLX.zig","created_at":"2025-03-14T14:47:09Z","description":"MLX.zig: Phi-4, Llama 3.2, and Whisper in Zig","default_branch":"main","open_issues":2,"stargazers_count":28,"forks_count":4,"watchers_count":28,"tags_url":"https://api.github.com/repos/jaco-bro/MLX.zig/tags","license":"Apache-2.0","topics":["llama","llm","mlx","pcre2","regex","tiktoken","zig","zig-package"],"size":5431,"fork":false,"updated_at":"2025-10-02T01:55:39Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":[]},{"avatar_url":"https://avatars.githubusercontent.com/u/201527030?v=4","name":"tokenizer","full_name":"jaco-bro/tokenizer","created_at":"2025-04-19T04:26:17Z","description":"BPE tokenizer for LLMs in Pure Zig","default_branch":"main","open_issues":0,"stargazers_count":5,"forks_count":3,"watchers_count":5,"tags_url":"https://api.github.com/repos/jaco-bro/tokenizer/tags","license":"Apache-2.0","topics":["bpe-tokenizer","pcre2","regex","tokenizer","zig","zig-package"],"size":305,"fork":false,"updated_at":"2025-09-10T20:08:12Z","has_build_zig":true,"has_build_zig_zon":true,"zig_minimum_version":"unknown","repo_from":"github","dependencies":[{"name":"pcre2","url":"https://github.com/PCRE2Project/pcre2","commit":"refs","tar_url":"https://github.com/PCRE2Project/pcre2/archive/refs.tar.gz","type":"remote"}],"dependents":["https://github.com/allyourcodebase/boost-libraries-zig"]}]
+    );
+    defer testing.allocator.free(mock_body);
+
+    try ctx.mock_client.expectRequest("https://api.example.com/search?filter=http", .ok, mock_body);
+
+    _ = try withCapturedOutput(&ctx.mock_client, struct {
+        fn run(client: *http_mock.MockHttpClient) !void {
+            try search.search_packages_with_client(testing.allocator, client, "*", "http");
+        }
+    }.run);
+
+    const requests = ctx.mock_client.getRequests();
+    try testing.expectEqual(@as(usize, 1), requests.len);
+    try testing.expect(!std.mem.containsAtLeast(u8, requests[0].url, 1, "q="));
+    try testing.expect(std.mem.containsAtLeast(u8, requests[0].url, 1, "filter=http"));
+}
+
+test "search_packages: empty strings treated as null" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const result = search.search_packages_with_client(testing.allocator, &ctx.mock_client, "", "");
+    try testing.expectError(error.InvalidSearchParameters, result);
+    try testing.expectEqual(@as(usize, 0), ctx.mock_client.getRequests().len);
+}
+
+test "search_packages: HTTP non-200 status" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const body = try testing.allocator.dupe(u8, "Not found");
+    defer testing.allocator.free(body);
+
+    try ctx.mock_client.expectRequest("https://api.example.com/search?q=test", .not_found, body);
+
+    _ = try withCapturedOutput(&ctx.mock_client, struct {
+        fn run(client: *http_mock.MockHttpClient) !void {
+            try search.search_packages_with_client(testing.allocator, client, "test", null);
+        }
+    }.run);
+
+    try testing.expectEqual(@as(usize, 1), ctx.mock_client.getRequests().len);
+}
+
+test "search_packages: memory allocation cleanup" {
+    var ctx = try TestContext.init(testing.allocator);
+    defer ctx.deinit();
+
+    const mock_body = try testing.allocator.dupe(u8,
+        \\ [{"name":"test-package","description":"A test package"}]
+    );
+    defer testing.allocator.free(mock_body);
+
+    try ctx.mock_client.expectRequest("https://api.example.com/search?q=test", .ok, mock_body);
+
+    // Test memory allocation during JSON parsing instead
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+
+    const result = search.search_packages_with_client(failing.allocator(), &ctx.mock_client, "test", null);
+    try testing.expectError(error.OutOfMemory, result);
+}


### PR DESCRIPTION
* Added tests for search module.
* Changed import approach - changed from relative path imports to package imports.  In general it is preferrable approach.
* Reverted single change: it have to be 
    const delimiters = switch (builtin.target.os.tag) {
        .windows => " \r\n\t",
        else => " \n\t",
    };
    It seems to me like accidental change, but I may be wrong - please let me know if I'm wrong.
    
    Thank u for developing project.